### PR TITLE
Make Go's encode function public

### DIFF
--- a/Go/bkkcrypt.go
+++ b/Go/bkkcrypt.go
@@ -1,5 +1,6 @@
 package bkkcrypt
 
-func encode(s string) string {
+// Encode encodes a string with the famous BKKCrypt algorithm.
+func Encode(s string) string {
 	return s
 }


### PR DESCRIPTION
We won't be able to call the `encode()` function in the go packge because it's private. This PR will fix it.