### PR TITLE
Fix Go code

### DIFF
--- a/Go/bkkcrypt.go
+++ b/Go/bkkcrypt.go
@@ -1,5 +1,6 @@
 package bkkcrypt
 
-func encode(s string) string {
+// Encode applies the encryption of BKK
+func Encode(s string) string {
 	return s
 }

--- a/Go/bkkcrypt_test.go
+++ b/Go/bkkcrypt_test.go
@@ -1,0 +1,15 @@
+package bkkcrypt
+
+import (
+	"testing"
+
+	bkkcrypt "github.com/moszinet/BKKCrypt/go"
+)
+
+func TestEncode(t *testing.T) {
+	password := "verysecret"
+
+	if bkkcrypt.Encode(password) != password {
+		t.Errorf("Expected %s", password)
+	}
+}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ An implementation of the famous BKKCrypt algorithm. Community contribution for o
 If you contribute and wish to be listed, please add your name to this list below:
 
 * Paydogs (Objective-C, Pascal)
-* moszinet (Javascript)
+* moszinet (Javascript, Go)
 * Skarlso (C++)
 * akoskovacs (Ruby, Assembly, Haskell, Erlang, Brainfuck)
 * pehsa (Batch, PowerShell, Python)
-
+* Yitsushi (Go)


### PR DESCRIPTION
In Go a function is exportable only if
 - start with capital letter
 - has a comment line that starts with the name of the function