### PR TITLE
Add units tests for Assembly, closes #28

### DIFF
--- a/Assembly/AMD64/Makefile
+++ b/Assembly/AMD64/Makefile
@@ -1,0 +1,21 @@
+AS        := gcc
+LD        := gcc
+RM        := rm
+AS_OBJS   := bkk_crypt_linux.o test_linux.o
+AS_TARGET := as_test
+
+all: test
+
+test: $(AS_TARGET)
+	@echo -n "Assembling and running asm tests... "
+	@(./$(AS_TARGET) && echo "[SUCCESS]") || echo "[FAIL]"
+
+$(AS_TARGET): $(AS_OBJS)
+	$(LD) $(AS_OBJS) -o $@
+
+%.o: %.s
+	$(AS) $^ -c
+
+.PHONY: clean
+clean:
+	$(RM) $(AS_OBJS) $(AS_TARGET)

--- a/Assembly/AMD64/test_linux.s
+++ b/Assembly/AMD64/test_linux.s
@@ -1,0 +1,55 @@
+# Copyleft (C) Ákos Kovács - 2017
+# Under MIT and BKK POLICEWARE Licenses
+
+# Use the Makefile to build it
+# Shell return values:
+# 0 - all tests passed
+# non-zero otherwise
+
+.global bkk_crypt
+.global strcmp
+.global exit
+
+.global main
+.type bkk_crypt, @function
+.type main, @function
+
+.section .rodata
+str0:
+    .string "We bust haxxors"
+str1:
+    .string "Safe plaintext\n"
+
+.section .text
+main:
+    # Call %rax = bkk_crypt(str0)
+    movq $str0, %rdi
+    callq bkk_crypt
+
+    # The result (in %rax) is the first parameter
+    movq %rax, %rdi
+    # str1 is the second paramter
+    movq $str0, %rsi
+    # strcmp(%rax, str0)
+    callq strcmp 
+    # Save for later
+    pushq %rax 
+
+    # Same as above, just with str1
+    movq $str1, %rdi
+    callq bkk_crypt
+
+    movq %rax, %rdi
+    movq $str1, %rsi
+    callq strcmp
+
+    # Restore the first one from the stack to %rbx
+    popq %rbx
+    # Or the test results together
+    # %rax = %rbx | %rax
+    orq %rbx, %rax
+   
+    # Complete test result on return
+    mov %rax, %rdi
+    call exit
+    ret

--- a/Assembly/Makefile
+++ b/Assembly/Makefile
@@ -1,0 +1,6 @@
+test:
+	@echo "Testing X86 Assembly..."
+	@$(MAKE) -C X86/
+
+	@echo "Testing X86-64 (AMD64) Assembly..."
+	@$(MAKE) -C AMD64/

--- a/Assembly/X86/Makefile
+++ b/Assembly/X86/Makefile
@@ -1,0 +1,23 @@
+AS        := gcc
+ASFLAGS   := -m32
+LD        := gcc
+LDFLAGS   := -m32
+RM        := rm
+AS_OBJS   := bkk_crypt_linux.o test_linux.o
+AS_TARGET := as_test
+
+all: test
+
+test: $(AS_TARGET)
+	@echo -n "Assembling and running asm tests... "
+	@(./$(AS_TARGET) && echo "[SUCCESS]") || echo "[FAIL]"
+
+$(AS_TARGET): $(AS_OBJS)
+	$(LD) $(AS_OBJS) -o $@ $(LDFLAGS)
+
+%.o: %.s
+	$(AS) $(ASFLAGS) $^ -c
+
+.PHONY: clean
+clean:
+	$(RM) $(AS_OBJS) $(AS_TARGET)

--- a/Assembly/X86/test_linux.s
+++ b/Assembly/X86/test_linux.s
@@ -1,0 +1,63 @@
+# Copyleft (Cd Ákos Kovács - 2017
+# Under MIT and BKK POLICEWARE Licenses
+
+# Use the Makefile to build it
+# Shell return values:
+# 0 - all tests passed
+# non-zero otherwise
+
+.global bkk_crypt
+.global strcmp
+.global exit
+
+.global main
+.type bkk_crypt, @function
+.type main, @function
+
+.section .rodata
+str0:
+    .string "We bust haxxors"
+str1:
+    .string "Safe plaintext\n"
+
+.section .text
+main:
+    # Call %eax = bkk_crypt(str0)
+    pushl $str0
+    call bkk_crypt
+    # Clear stack
+    popl %ebx
+
+    # The result (in %eax) is the first parameter
+    pushl %eax
+    # str0 is the second paramter
+    push $str0
+    # strcmp(%eax, str0)
+    call strcmp 
+    # Clear both, being lazy with the stack now
+    popl %ebx
+    popl %ebx
+    # Save for later
+    push %eax 
+
+    # Same as above, just with str1
+    pushl $str1
+    call bkk_crypt
+    popl %ebx
+
+    pushl %eax
+    pushl $str1
+    call strcmp
+    popl %ebx
+    popl %ebx
+
+    # Restore the first one from the stack to %ebx
+    popl %ebx
+    # Or the test results together
+    # %eax = %ebx | %eax
+    orl %ebx, %eax
+   
+    # Complete test result on return
+    push %eax
+    call exit
+    ret


### PR DESCRIPTION
Create assembly unit tests and Makefiles for the GNU/Linux x86 and amd64 implementations.